### PR TITLE
xcur2png.c: fix `gcc-14` build

### DIFF
--- a/xcur2png.c
+++ b/xcur2png.c
@@ -671,7 +671,7 @@ int saveConfAndPNGs (const XcursorImages* xcIs, const char* xcurFilePart, int su
   int ret;
   int count = 0;
   char pngName[PATH_MAX] = {0};
-  extern dry_run;
+  extern int dry_run;
   
   //Write comment on config-file.
   fprintf (conffp,"#size\txhot\tyhot\tPath to PNG image\tdelay\n");


### PR DESCRIPTION
Without the change the build on `gcc-14` fails as:

    xcur2png.c: In function 'saveConfAndPNGs':
    xcur2png.c:690:10: error: type defaults to 'int' in declaration of 'dry_run' [-Wimplicit-int-Wimplicit-int]
      690 |   extern dry_run;
          |          ^~~~~~~