### PR TITLE
Fixed png encoding int overflow

### DIFF
--- a/xcur2png.c
+++ b/xcur2png.c
@@ -586,9 +586,12 @@ int writePngFileFromXcur (const XcursorDim width, const XcursorDim height,
     unsigned int red = (pixels[i]>>16) & 0xff;
     unsigned int green = (pixels[i]>>8) & 0xff;
     unsigned int blue = pixels[i] & 0xff;
-    red = (div (red * 256, alpha).quot) & 0xff;
-    green = (div (green * 256,  alpha).quot) & 0xff;
-    blue = (div (blue * 256, alpha).quot) & 0xff;
+    red = (div (red * 256, alpha).quot);
+    green = (div (green * 256,  alpha).quot);
+    blue = (div (blue * 256, alpha).quot);
+    red = (red > 0xff ? 0xff : red) & 0xff;
+    green = (green > 0xff ? 0xff : green) & 0xff;
+    blue = (blue > 0xff ? 0xff : blue) & 0xff;
     pix[i] = (alpha << 24) + (red << 16) + (green << 8) + blue;
   }
 
@@ -671,7 +674,7 @@ int saveConfAndPNGs (const XcursorImages* xcIs, const char* xcurFilePart, int su
   int ret;
   int count = 0;
   char pngName[PATH_MAX] = {0};
-  extern dry_run;
+  extern int dry_run;
   
   //Write comment on config-file.
   fprintf (conffp,"#size\txhot\tyhot\tPath to PNG image\tdelay\n");


### PR DESCRIPTION
(This PR also includes [trophi's #4](https://github.com/eworm-de/xcur2png/pull/4), because it wouldn't build without that)

The following code on 589-591 translates Xcursor's alpha premultiplied RGB values to raw RGB values for PNG:

```
red = (div (red * 256, alpha).quot) & 0xff;
green = (div (green * 256,  alpha).quot) & 0xff;
blue = (div (blue * 256, alpha).quot) & 0xff;
```

This breaks when any of the RGB values is equal to alpha, because they simply cancel out in the division and the result is 256, which is 0x100 and gets masked out by 0xff. For example, pure white values (255, 255, 255, 255) get turned to pure black (0, 0, 0, 255) when run through this code. This PR solves this by setting the RGB values to the minimum of their old values and 255.